### PR TITLE
Darstellung der Navigation verbessern

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -151,7 +151,8 @@ NAVIGATION
     display: block;
     position: absolute;
     transform: rotate(45deg);
-    left: 45%;
+    left: 50%;
+    margin-left: -10px;
 
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -129,18 +129,24 @@ NAVIGATION
     font-weight: 700;
 
 }
-#navi ul li a:hover{
-    background-color: #FFF;
-    color: #2e2750;
-    outline: 10px solid #FFF;
-}
-
+#navi ul li a:hover,
 #navi ul li a.active{
     background-color: #FFF;
     color: #2e2750;
-    outline: 10px solid #FFF;
     position: relative;
-    overflow: visible;
+}
+
+#navi ul li a:hover::before,
+#navi ul li a.active::before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    background: transparent;
+    border: solid #FFF;
+    border-width: 13px 10px;
+    left: -10px;
+    top: -13px;
 }
 
 #navi ul li a.active::after {


### PR DESCRIPTION
Im Firefox wurden die aktiven Navigationspunkte falsch angezeigt:
<img width="314" alt="bildschirmfoto 2016-02-14 um 15 25 02" src="https://cloud.githubusercontent.com/assets/68697/13034483/bf752b54-d336-11e5-8474-5ce0698d78a4.png">
Das wird hiermit geändert.

Dabei ist mir auch aufgefallen, dass die Positionierung der Pfeile nicht ganz genau zentriert war. Das habe ich auch noch angepasst.