### PR TITLE
Verbesserungen Admin-Bereich und erleichterter Einstieg für Entwickler

### DIFF
--- a/app/controllers/games.js
+++ b/app/controllers/games.js
@@ -14,13 +14,13 @@ var GamesController = {
             homepage: data.homepage,
             coverart: data.coverart,
             trailerID: data.trailerID,
-            official: data.official,
-            community: data.community,
-            active: data.active,
-            released: data.released,
+            official: data.official == 'on',
+            community: data.community == 'on',
+            active: data.active == 'on',
+            released: data.released == 'on',
             releasedate: data.releasedate,
             platforms: platforms,
-            new: data.new
+            new: data.new == 'on'
         });
 
         game.save(function (err) {
@@ -38,12 +38,12 @@ var GamesController = {
             game.homepage = data.homepage;
             game.coverart = data.coverart;
             game.trailerID = data.trailerID;
-            game.official = data.official;
-            game.community = data.community;
-            game.active = data.active;
-            game.released = data.released;
+            game.official = data.official == 'on';
+            game.community = data.community == 'on';
+            game.active = data.active == 'on';
+            game.released = data.released == 'on';
             game.releasedate = data.releasedate;
-            game.new = data.new;
+            game.new = data.new == 'on';
 
             // platforms..
 

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -2,15 +2,15 @@ var Settings = require('../models/settings');
 
 var SettingsController = {
     isVotingOpen: function (callback) {
-        Settings.findOne({name: 'primarySettings'}, function (err, obj) {
-            if (err) return handleError(err);
-            callback(obj.votingOpen);
+        this.getPrimarySettings(function(settings) {
+            callback(settings.votingOpen == true);
         });
     },
     togglePoll: function (callback) {
-        Settings.findOne({name: 'primarySettings'}, function (err, obj) {
-            if (err) return handleError(err);
+        this.getPrimarySettings(function (obj) {
             //var val = JSON.parse(obj.value);
+            obj = obj || new Settings();
+
             if (obj.votingOpen)
                 val = false;
             else
@@ -27,8 +27,8 @@ var SettingsController = {
         });
     },
     setPollId: function (id) {
-        Settings.findOne({name: 'primarySettings'}, function (err, obj) {
-            if (err) return handleError(err);
+        this.getPrimarySettings(function (obj) {
+            obj = obj || new Settings();
             obj.pollId = id;
 
             obj.save(function (err) {
@@ -37,9 +37,20 @@ var SettingsController = {
         });
     },
     getPollId: function (callback) {
+        this.getPrimarySettings(function (obj) {
+            callback(obj.pollId);
+        });
+    },
+    getPrimarySettings: function(callback) {
         Settings.findOne({name: 'primarySettings'}, function (err, obj) {
             if (err) return handleError(err);
-            callback(obj.pollId);
+
+            if (!obj) {
+                obj = new Settings();
+                obj.name = 'primarySettings';
+            }
+
+            callback(obj);
         });
     }
 };

--- a/app/views/edit.jade
+++ b/app/views/edit.jade
@@ -4,43 +4,43 @@ block content
         h1 #{game.title}
         form(action='/save' method='post')
             div.form-group
-                label title
-                input.form-control(type='text' name='title' value='#{game.title}')
+                label(for='title') title
+                input.form-control(type='text' id='title' name='title' value='#{game.title}')
             div.form-group
-                label description
-                input.form-control(type='text' name='description' value='#{game.description}')
+                label(for='description') description
+                input.form-control(type='text' id='description' name='description' value='#{game.description}')
             div.form-group
-                label dev
-                input.form-control(type='text' name='developer' value='#{game.developer}')
+                label(for='developer') dev
+                input.form-control(type='text' id='developer' name='developer' value='#{game.developer}')
             div.form-group
-                label publisher
-                input.form-control(type='text' name='publisher' value='#{game.publisher}')
+                label(for='publisher') publisher
+                input.form-control(type='text' id='publisher' name='publisher' value='#{game.publisher}')
             div.form-group
-                label homepage
-                input.form-control(type='text' name='homepage' value='#{game.homepage}')
+                label(for='homepage') homepage
+                input.form-control(type='text' id='homepage' name='homepage' value='#{game.homepage}')
             div.form-group
-                label coverart
-                input.form-control(type='text' name='coverart' value='#{game.coverart}')
+                label(for='coverart') coverart
+                input.form-control(type='text' id='coverart' name='coverart' value='#{game.coverart}')
             div.form-group
-                label Video ID
-                input.form-control(type='text' name='trailerID' value='#{game.trailerID}')
+                label(for='trailerID') Video ID
+                input.form-control(type='text' id='trailerID' name='trailerID' value='#{game.trailerID}')
             div.form-group
-                label releasedate
-                input.form-control(type='text' name='releasedate' value='#{game.releasedate}')
+                label(for='releasedate') releasedate
+                input.form-control(type='text' id='releasedate' name='releasedate' value='#{game.releasedate}')
             div.form-group
-                label community
-                input.form-control(type='text' name='community' value='#{game.community}')
+                label(for='community') community
+                input.form-control(type='checkbox' id='community' name='community' checked=game.community ? 'checked' : null)
             div.form-group
-                label official
-                input.form-control(type='text' name='official' value='#{game.official}')
+                label(for='official') official
+                input.form-control(type='checkbox' id='official' name='official' checked=game.official ? 'checked' : null)
             div.form-group
-                label active
-                input.form-control(type='text' name='active' value='#{game.active}')
+                label(for='active') active
+                input.form-control(type='checkbox' id='active' name='active' checked=game.active ? 'checked' : null)
             div.form-group
-                label released
-                input.form-control(type='text' name='released' value='#{game.released}')
+                label(for='released') released
+                input.form-control(type='checkbox' id='released' name='released' checked=game.released ? 'checked' : null)
             div.form-group
-                label new
-                input.form-control(type='text' name='new' value='#{game.new}')
+                label(for='new') new
+                input.form-control(type='checkbox' id='new' name='new' checked=game.new ? 'checked' : null)
             input(type='hidden' name='_id' value='#{game._id}')
             button.btn.btn-warning.btn-lg(type='submit') Save changes

--- a/app/views/new.jade
+++ b/app/views/new.jade
@@ -29,17 +29,17 @@ block content
                 input.form-control(type='text' name='releasedate')
             div.form-group
                 label community
-                input.form-control(type='text' name='community')
+                input.form-control(type='checkbox' name='community')
             div.form-group
                 label official
-                input.form-control(type='text' name='official')
+                input.form-control(type='checkbox' name='official')
             div.form-group
                 label active
-                input.form-control(type='text' name='active')
+                input.form-control(type='checkbox' name='active' checked='checked')
             div.form-group
                 label released
-                input.form-control(type='text' name='released')
+                input.form-control(type='checkbox' name='released')
             div.form-group
                 label new
-                input.form-control(type='text' name='new')
+                input.form-control(type='checkbox' name='new')
             button.btn.btn-warning.btn-lg(type='submit') Add Game

--- a/app/views/signup.jade
+++ b/app/views/signup.jade
@@ -1,0 +1,18 @@
+extends layouts/layout
+block content
+    div.well
+        h1
+            span.fa.fa-sign-in Signup
+        if message.length > 0
+            div.alert.alert-danger #{message}
+
+        form(action='/signup' method='post')
+            div.form-group
+                label Email
+                input.form-control(type='text' name='email')
+            div.form-group
+                label Password
+                input.form-control(type='password' name='password')
+
+            button.btn.btn-warning.btn-lg(type='submit') Signup
+        hr

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -505,3 +505,29 @@ MISC
   color: whitesmoke !important;
   text-decoration: underline;
 }
+
+form .form-group {
+    height: 40px;
+    margin-bottom: 5px;
+}
+
+form .form-group label {
+    float: left;
+    width: 200px;
+
+    text-align: right;
+    margin: 3px 10px 3px 3px;
+
+    padding: 1px;
+
+    font-size: 150%;
+}
+
+form .form-group input[type='text'],
+form .form-group input[type='password'] {
+    font-family: 'Oswald', sans-serif;
+}
+
+form .form-group input[type='checkbox'] {
+    margin-top: 18px;
+}


### PR DESCRIPTION
Ich habe ein paar Dinge am admin-Bereich verbessert:
- Checkboxen für die Boolean Eigenschaften
- Styling des Create/Edit-Formulars
- Label den Eingabefeldern zugeordnet

Außerdem habe ich ein paar Dinge angepasst, die den Einstieg für Entwickler etwas erleichtern:
- Fehlende View für das Signup-Formular hinzugefügt
- Die primarySettings wurden vorher nie angelegt, ich vermute dass man sie von Hand in die Datenbank hätte schreiben müssen. Jetzt werden sie angelegt, sobald eine Einstellung verändert wird - und wenn sie nicht da sind funktioniert das System trotzdem